### PR TITLE
Fix invalid insetting calculations

### DIFF
--- a/Sources/AutoInsetter/AutoInsetter.swift
+++ b/Sources/AutoInsetter/AutoInsetter.swift
@@ -111,11 +111,8 @@ private extension AutoInsetter {
             
         } else { // Standard View controller
             
-            guard let superview = scrollView.superview else {
-                return scrollView.contentInset
-            }
-            
-            let relativeFrame = viewController.view.convert(scrollView.frame, from: superview)
+            let relativeSuperview = viewController.view
+            let relativeFrame = viewController.view.convert(scrollView.frame, from: relativeSuperview)
             let relativeTopInset = max(requiredContentInset.top - relativeFrame.minY, 0.0)
             let bottomInsetMinY = viewController.view.bounds.height - requiredContentInset.bottom
             let relativeBottomInset = fabs(min(bottomInsetMinY - relativeFrame.maxY, 0.0))

--- a/Sources/AutoInsetter/Utilities/UIViewController+ScrollViewDetection.swift
+++ b/Sources/AutoInsetter/Utilities/UIViewController+ScrollViewDetection.swift
@@ -24,11 +24,13 @@ internal extension UIViewController {
         var scrollViews = [UIScrollView]()
         
         for subview in view.subviews {
+            // if current view is scroll view add it and ignore the subviews
+            // - as it can be assumed they will be insetted correctly within the parent scroll view.
             if let scrollView = subview as? UIScrollView {
                 scrollViews.append(scrollView)
+            } else {
+                scrollViews.append(contentsOf: self.scrollViews(in: subview))
             }
-            
-            scrollViews.append(contentsOf: self.scrollViews(in: subview))
         }
         return scrollViews
     }


### PR DESCRIPTION
- Incorrect superview would be used for child subview relative calculations causing invalid values. uias/Tabman#264
- Scroll views were unnecessarily evaluated and insetted when contained within parent scroll views that were already insetted.