### PR TITLE
Maintain UIScrollView left/right contentInset

### DIFF
--- a/Sources/AutoInsetter/AutoInsetter.swift
+++ b/Sources/AutoInsetter/AutoInsetter.swift
@@ -117,11 +117,12 @@ private extension AutoInsetter {
             let relativeTopInset = max(requiredContentInset.top - relativeFrame.minY, 0.0)
             let bottomInsetMinY = viewController.view.bounds.height - requiredContentInset.bottom
             let relativeBottomInset = fabs(min(bottomInsetMinY - relativeFrame.maxY, 0.0))
+            let originalContentInset = scrollView.contentInset
             
             proposedContentInset = UIEdgeInsets(top: relativeTopInset,
-                                                left: 0.0,
+                                                left: originalContentInset.left,
                                                 bottom: relativeBottomInset,
-                                                right: 0.0)
+                                                right: originalContentInset.right)
         }
         
         currentScrollViewInsets[scrollView] = proposedContentInset


### PR DESCRIPTION
Noticed this in GitHawkApp/GitHawk#1988. We use left/right inset to add padding to our view, but AutoInsetter is clearing those inset values.

Not sure the process for updating this library and seeing the effects in Tabman. Will we need to bump a new CocoaPods release, update Tabman, _then_ update GitHawk? I ask b/c this bug is blocking our latest release.

Thanks!

cc @msaps 