### PR TITLE
Fix incorrect view positioning calculations

### DIFF
--- a/Sources/AutoInsetter.xcodeproj/project.pbxproj
+++ b/Sources/AutoInsetter.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		460463C5223CF3A100E19258 /* TableViewControllerTestViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 460463C4223CF3A100E19258 /* TableViewControllerTestViewController.swift */; };
+		460463C7223CF44E00E19258 /* EmbeddedChildTestViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 460463C6223CF44E00E19258 /* EmbeddedChildTestViewController.swift */; };
 		460911B1200E5291008DC38E /* AutoInsetter.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 460911A7200E5291008DC38E /* AutoInsetter.framework */; };
 		461197182221C43C0033FE04 /* AutoInsetter.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 460911A7200E5291008DC38E /* AutoInsetter.framework */; };
 		461197192221C4840033FE04 /* Pageboy.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 46F4BEAA216FC4DC002616F0 /* Pageboy.framework */; };
@@ -75,6 +76,7 @@
 
 /* Begin PBXFileReference section */
 		460463C4223CF3A100E19258 /* TableViewControllerTestViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TableViewControllerTestViewController.swift; sourceTree = "<group>"; };
+		460463C6223CF44E00E19258 /* EmbeddedChildTestViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmbeddedChildTestViewController.swift; sourceTree = "<group>"; };
 		460911A7200E5291008DC38E /* AutoInsetter.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = AutoInsetter.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		460911B0200E5291008DC38E /* AutoInsetterTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = AutoInsetterTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		464CFD8720111C5000D7DEDA /* EmbeddedScrollViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmbeddedScrollViewTests.swift; sourceTree = "<group>"; };
@@ -225,6 +227,7 @@
 				46F4BE9C216FC46E002616F0 /* TableViewTestViewController.swift */,
 				46F4BE9D216FC46E002616F0 /* CollectionViewTestViewController.swift */,
 				460463C4223CF3A100E19258 /* TableViewControllerTestViewController.swift */,
+				460463C6223CF44E00E19258 /* EmbeddedChildTestViewController.swift */,
 			);
 			path = ViewControllers;
 			sourceTree = "<group>";
@@ -486,6 +489,7 @@
 				46F4BEA2216FC46E002616F0 /* ScenarioListViewController.swift in Sources */,
 				46F4BE88216FC43A002616F0 /* AppDelegate.swift in Sources */,
 				46F4BEA3216FC46E002616F0 /* TableViewTestViewController.swift in Sources */,
+				460463C7223CF44E00E19258 /* EmbeddedChildTestViewController.swift in Sources */,
 				46F4BEA5216FC46E002616F0 /* Scenario.swift in Sources */,
 				46F4BEA4216FC46E002616F0 /* CollectionViewTestViewController.swift in Sources */,
 			);

--- a/Sources/AutoInsetter/AutoInsetter.swift
+++ b/Sources/AutoInsetter/AutoInsetter.swift
@@ -156,8 +156,7 @@ private extension AutoInsetter {
             
         } else { // Standard View controller
             
-            let relativeSuperview = viewController.view
-            let relativeFrame = viewController.view.convert(scrollView.frame, from: relativeSuperview)
+            let relativeFrame = viewController.view.convert(scrollView.frame, from: scrollView.superview)
             let relativeTopInset = max(requiredContentInset.top - relativeFrame.minY, 0.0)
             let bottomInsetMinY = viewController.view.bounds.height - requiredContentInset.bottom
             let relativeBottomInset = abs(min(bottomInsetMinY - relativeFrame.maxY, 0.0))

--- a/Sources/AutoInsetterPlayground/Scenarios/Scenario.swift
+++ b/Sources/AutoInsetterPlayground/Scenarios/Scenario.swift
@@ -12,6 +12,7 @@ enum Scenario: CaseIterable {
     case uiTableView
     case uiTableViewController
     case uiCollectionView
+    case childUIScrollView
 }
 
 extension Scenario {
@@ -24,6 +25,8 @@ extension Scenario {
             return "UITableViewController"
         case .uiCollectionView:
             return "UICollectionView"
+        case .childUIScrollView:
+            return "Child UIScrollView"
         }
     }
     
@@ -42,6 +45,8 @@ extension Scenario {
             return ScenarioViewController<CollectionViewTestViewController>.init(scenario: self)
         case .uiTableViewController:
             return ScenarioViewController<TableViewControllerTestViewController>.init(scenario: self)
+        case .childUIScrollView:
+            return ScenarioViewController<EmbeddedChildTestViewController>.init(scenario: self)
         }
     }
 }

--- a/Sources/AutoInsetterPlayground/Scenarios/ViewControllers/EmbeddedChildTestViewController.swift
+++ b/Sources/AutoInsetterPlayground/Scenarios/ViewControllers/EmbeddedChildTestViewController.swift
@@ -1,0 +1,30 @@
+//
+//  EmbeddedChildTestViewController.swift
+//  AutoInsetterPlayground
+//
+//  Created by Merrick Sapsford on 16/03/2019.
+//  Copyright © 2019 UI At Six. All rights reserved.
+//
+
+import UIKit
+
+class EmbeddedChildTestViewController: UIViewController {
+    
+    let child = TableViewTestViewController()
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        addChild(child)
+        view.addSubview(child.view)
+        child.view.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            child.view.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            child.view.topAnchor.constraint(equalTo: view.topAnchor, constant: 200.0),
+            view.trailingAnchor.constraint(equalTo: child.view.trailingAnchor),
+            view.bottomAnchor.constraint(equalTo: child.view.bottomAnchor)
+            ])
+        
+        child.view.backgroundColor = UIColor.red.withAlphaComponent(0.5)
+    }
+}

--- a/Sources/AutoInsetterPlayground/Scenarios/ViewControllers/TableViewTestViewController.swift
+++ b/Sources/AutoInsetterPlayground/Scenarios/ViewControllers/TableViewTestViewController.swift
@@ -47,6 +47,7 @@ class TableViewTestViewController: UIViewController, UITableViewDataSource, UITa
         }
         
         cell.textLabel?.text = "Row \(indexPath.row)"
+        cell.backgroundColor = .clear
         
         return cell
     }

--- a/Sources/AutoInsetterPlayground/Scenarios/ViewControllers/TableViewTestViewController.swift
+++ b/Sources/AutoInsetterPlayground/Scenarios/ViewControllers/TableViewTestViewController.swift
@@ -18,6 +18,9 @@ class TableViewTestViewController: UIViewController, UITableViewDataSource, UITa
         tableView.dataSource = self
         tableView.delegate = self
         
+        view.backgroundColor = .white
+        tableView.backgroundColor = .clear
+        
         view.addSubview(tableView)
         tableView.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([


### PR DESCRIPTION
Fixes issue where AutoInsetter would incorrectly calculate the 'relative' frame of a candidate view due to using the incorrect `superview`. #11 